### PR TITLE
Support develocity APIs in JUnitXml handling

### DIFF
--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/FladlePluginDelegate.kt
@@ -142,7 +142,7 @@ class FladlePluginDelegate {
     }
     if (config.localResultsDir.hasValue && canImportReport()) {
       try {
-        importReport(this@createTasksForConfig, execFlank)
+        importReport(project, execFlank)
       } catch (e: Exception) {
         project.logger.warn(e.message)
         e.printStackTrace()

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/ImportReportDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/ImportReportDelegate.kt
@@ -1,28 +1,68 @@
+@file:Suppress("DEPRECATION")
+
 package com.osacky.flank.gradle
 
-import com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports
-import com.gradle.enterprise.gradleplugin.test.JUnitXmlDialect
+import org.gradle.api.Project
+import com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports as GEImportJUnitXmlReports
+import com.gradle.enterprise.gradleplugin.test.JUnitXmlDialect as GEJUnitXmlDialect
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports as DevelocityImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect as DevelocityJUnitXmlDialect
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
-fun canImportReport(): Boolean {
-  return try {
-    Class.forName("com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports")
-    true
-  } catch (e: ClassNotFoundException) {
-    false
-  }
-}
+fun canImportReport(): Boolean = JUnitXmlHandler.canImport()
 
-fun importReport(tasks: TaskContainer, flankTask: TaskProvider<FlankExecutionTask>) {
+fun importReport(project: Project, flankTask: TaskProvider<FlankExecutionTask>) {
   val enableTestUploads = flankTask.get().project.providers
     .gradleProperty("com.osacky.fladle.enableTestUploads")
-    .forUseAtConfigurationTime()
     .getOrElse("true")
     .toBoolean()
   if (enableTestUploads) {
-    ImportJUnitXmlReports.register(tasks, flankTask, JUnitXmlDialect.ANDROID_FIREBASE).configure {
-      reports.setFrom("${project.buildDir}/fladle/${flankTask.get().config.localResultsDir.get()}/JUnitReport.xml")
+    JUnitXmlHandler.get()?.register(project.tasks, flankTask, "${project.buildDir}/fladle/${flankTask.get().config.localResultsDir.get()}/JUnitReport.xml")
+  }
+}
+
+/** Abstraction over Develocity and GE impls of JUnitXml reporting. */
+sealed class JUnitXmlHandler {
+
+  abstract fun register(tasks: TaskContainer, flankTask: TaskProvider<FlankExecutionTask>, reportsPath: String)
+
+  companion object {
+    private fun canImport(name: String) = try {
+      Class.forName(name)
+      true
+    } catch (e: ClassNotFoundException) {
+      false
+    }
+
+    private val canImportDevelocity get() = canImport("com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports")
+
+    private val canImportGE get() = canImport("com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports")
+
+    fun canImport() = canImportDevelocity || canImportGE
+
+    fun get() = if (canImportDevelocity) {
+      DevelocityJunitXmlHandler
+    } else if (canImportGE) {
+      GEJunitXmlHandler
+    } else {
+      null
+    }
+  }
+
+  object DevelocityJunitXmlHandler : JUnitXmlHandler() {
+    override fun register(tasks: TaskContainer, flankTask: TaskProvider<FlankExecutionTask>, reportsPath: String) {
+      DevelocityImportJUnitXmlReports.register(tasks, flankTask, DevelocityJUnitXmlDialect.ANDROID_FIREBASE).configure {
+        this.reports.setFrom(reportsPath)
+      }
+    }
+  }
+
+  object GEJunitXmlHandler : JUnitXmlHandler() {
+    override fun register(tasks: TaskContainer, flankTask: TaskProvider<FlankExecutionTask>, reportsPath: String) {
+      GEImportJUnitXmlReports.register(tasks, flankTask, GEJUnitXmlDialect.ANDROID_FIREBASE).configure {
+        this.reports.setFrom(reportsPath)
+      }
     }
   }
 }

--- a/fladle-plugin/src/main/java/com/osacky/flank/gradle/ImportReportDelegate.kt
+++ b/fladle-plugin/src/main/java/com/osacky/flank/gradle/ImportReportDelegate.kt
@@ -6,12 +6,12 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports as GEImportJUnitXmlReports
-import com.gradle.enterprise.gradleplugin.test.JUnitXmlDialect as GEJUnitXmlDialect
-import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports as DevelocityImportJUnitXmlReports
-import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect as DevelocityJUnitXmlDialect
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports as DevelocityImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect as DevelocityJUnitXmlDialect
+import com.gradle.enterprise.gradleplugin.test.ImportJUnitXmlReports as GEImportJUnitXmlReports
+import com.gradle.enterprise.gradleplugin.test.JUnitXmlDialect as GEJUnitXmlDialect
 
 fun canImportReport(): Boolean = JUnitXmlHandler.canImport()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,6 @@ junit = { group = "junit", name = "junit", version.ref = "junit-version" }
 
 kotlin-stdlib-jdk7 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk7", version.ref = "kotlin" }
 
-gradle-enterprise = { module = "com.gradle:gradle-enterprise-gradle-plugin", version = "3.16.1" }
+gradle-enterprise = { module = "com.gradle:gradle-enterprise-gradle-plugin", version = "3.17.1" }
 
 truth = "com.google.truth:truth:1.3.0"


### PR DESCRIPTION
This also modernizes some of the report file handling and supports both GE and develocity behind a `JUnitXmlHandler` abstraction.